### PR TITLE
no need to explicitly add default activity anymore

### DIFF
--- a/apk-lib/app/src/main/AndroidManifest.xml
+++ b/apk-lib/app/src/main/AndroidManifest.xml
@@ -7,17 +7,6 @@
     <!--We let the application tag inherit its attributes from the source app.-->
     <application>
 
-        <!--As a convenience, due to this bug in Android Studio:
-            https://code.google.com/p/android/issues/detail?id=168306
-            We surface part of the default activity to the main manifest
-            so that Studio will not complain when launching the app.-->
-        <activity android:name="makeinfo.com.getid.MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity>
-
         <!--This activity is required by the file chooser we imported:
             https://github.com/bartwell/ExFilePicker#usage -->
         <activity

--- a/invalid-resources/app/src/main/AndroidManifest.xml
+++ b/invalid-resources/app/src/main/AndroidManifest.xml
@@ -7,17 +7,6 @@
     <!--We let the application tag inherit its attributes from the source app.-->
     <application>
 
-        <!--As a convenience, due to this bug in Android Studio:
-            https://code.google.com/p/android/issues/detail?id=168306
-            We surface part of the default activity to the main manifest
-            so that Studio will not complain when launching the app.-->
-        <activity android:name="makeinfo.com.getid.MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity>
-
         <!--This activity is required by the file chooser we imported:
             https://github.com/bartwell/ExFilePicker#usage -->
         <activity

--- a/multi-dex/app/src/main/AndroidManifest.xml
+++ b/multi-dex/app/src/main/AndroidManifest.xml
@@ -7,17 +7,6 @@
     <!--We let the application tag inherit its attributes from the source app.-->
     <application>
 
-        <!--As a convenience, due to this bug in Android Studio:
-            https://code.google.com/p/android/issues/detail?id=168306
-            We surface part of the default activity to the main manifest
-            so that Studio will not complain when launching the app.-->
-        <activity android:name="makeinfo.com.getid.MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity>
-
         <!--This activity is required by the file chooser we imported:
             https://github.com/bartwell/ExFilePicker#usage -->
         <activity

--- a/patch-lib/app/src/main/AndroidManifest.xml
+++ b/patch-lib/app/src/main/AndroidManifest.xml
@@ -7,17 +7,6 @@
     <!--We let the application tag inherit its attributes from the source app.-->
     <application>
 
-        <!--As a convenience, due to this bug in Android Studio:
-            https://code.google.com/p/android/issues/detail?id=168306
-            We surface part of the default activity to the main manifest
-            so that Studio will not complain when launching the app.-->
-        <activity android:name="makeinfo.com.getid.MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity>
-
     </application>
 
 </manifest>


### PR DESCRIPTION
The issue with Android studio has been fixed in beta and will soon be available in `4.0.1` release. I've tested the `patched-app` with `4.1 beta2` and it indeed is working.
ref: https://issuetracker.google.com/issues/158019870